### PR TITLE
Add reportError callback function, add to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ type ExceptionScope<Context> = (
 
 ### Filtering Out Custom Errors
 
-To filter out custom errors thrown by your server (such as "You Are Not Logged In"), use the `reportError` option and return a boolean for whether or not the error should be
+To filter out custom errors thrown by your server (such as "You Are Not Logged In"), use the `reportError` option and return a boolean for whether or not the error should be sent to sentry.
 
 ```ts
 class CustomError extends Error {}

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ export interface Options<Context> {
   withScope?: ExceptionScope<Context>
   captureReturnedErrors?: boolean
   forwardErrors?: boolean
-  reportError?: (res) => boolean
+  reportError?: (res: Error | any) => boolean
 }
 
 function sentry<Context>(options: Options<Context>): IMiddlewareFunction

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ export interface Options<Context> {
   withScope?: ExceptionScope<Context>
   captureReturnedErrors?: boolean
   forwardErrors?: boolean
+  reportError?: (res) => boolean
 }
 
 function sentry<Context>(options: Options<Context>): IMiddlewareFunction
@@ -82,6 +83,32 @@ type ExceptionScope<Context> = (
 ) => void
 ```
 
+### Filtering Out Custom Errors
+
+To filter out custom errors thrown by your server (such as "You Are Not Logged In"), use the `reportError` option and return a boolean for whether or not the error should be
+
+```ts
+class CustomError extends Error {}
+
+const sentryMiddleware = sentry({
+  reportError: (res) => {
+    // you can check the error message strings
+    if (res.message === 'You Are Not Logged In') {
+      return false;
+    }
+
+    // or extend the error type and create a custom error
+    if (res instanceof CustomError) {
+      return false;
+    }
+
+    return true;
+  }
+})
+```
+
+
+
 ### Options
 
 | property                | required | description                                                                                                                                                                |
@@ -90,6 +117,7 @@ type ExceptionScope<Context> = (
 | `withScope`             | false    | Function to modify the [Sentry context](https://docs.sentry.io/enriching-error-data/context/?platform=node) to send with the captured error.                               |
 | `captureReturnedErrors` | false    | Capture errors returned from other middlewares, e.g., `graphql-shield` [returns errors](https://github.com/maticzav/graphql-shield#custom-errors) from rules and resolvers |
 | `forwardErrors`         | false    | Should middleware forward errors to the client or block them.                                                                                                              |
+| `reportError` | false | Function that passes `res` as the parameter and accepts a boolean callback for whether or not the error should be captured
 
 ## License
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,12 +17,6 @@ export interface Options<Context> {
   reportError?: (res) => boolean
 }
 
-function containsIgnoredError(res, ignoredErrors) {
-  ignoredErrors.some(error => {
-    return res instanceof error;
-  });
-}
-
 export class SentryError extends Error {}
 
 export const sentry = <Context>({
@@ -45,13 +39,15 @@ export const sentry = <Context>({
     try {
       const res = await resolve(parent, args, ctx, info)
 
-      if (reportError && reportError(res)) {
+      if (reportError && !reportError(res)) {
+        // if there's a report error function but it returns false, ignore the error
         return res;
       }
 
       if (captureReturnedErrors && res instanceof Error) {
         captureException(res, ctx, withScope)
       }
+
       return res
     } catch (err) {
       captureException(err, ctx, withScope)

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,7 +62,7 @@ function captureException<Context>(
   withScope: ExceptionScope<Context>,
   reportError?: (res) => boolean,
 ) {
-  if (reportError && !reportError(err)) {
+  if (reportError && reportError(err) || !reportError) {
     Sentry.withScope(scope => {
       withScope(scope, err, ctx)
       Sentry.captureException(err)


### PR DESCRIPTION
Resolves #40 

I'm open to input for the name of the config, but I think this implementation should be the most extensible to allow someone to run any kind of validation for whether or not the error should be reported.

Here's a summary from the additions to the README:

### Filtering Out Custom Errors

To filter out custom errors thrown by your server (such as "You Are Not Logged In"), use the `reportError` option and return a boolean for whether or not the error should be sent to Sentry.

```ts
class CustomError extends Error {}

const sentryMiddleware = sentry({
  reportError: (res) => {
    // you can check the error message strings
    if (res.message === 'You Are Not Logged In') {
      return false;
    }

    // or extend the error type and create a custom error
    if (res instanceof CustomError) {
      return false;
    }

    return true;
  }
})
```