### PR TITLE
Use identity function as default for withScope

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ export class SentryError extends Error {}
 export const sentry = <Context>({
   sentryInstance = null,
   config = {},
-  withScope,
+  withScope = () => {},
   captureReturnedErrors = false,
   forwardErrors = false,
   reportError,


### PR DESCRIPTION
Resolves #134.